### PR TITLE
Support multiple select inputs and array handling

### DIFF
--- a/www/htdocs/central/dataentry/editor/renderers/SelectRenderer.php
+++ b/www/htdocs/central/dataentry/editor/renderers/SelectRenderer.php
@@ -128,7 +128,10 @@ class SelectRenderer {
                 }
             }
             $subc = rtrim($t[5]);
-            echo "<select name=tag$tag $TipoS id=tag$tag";
+            $TipoS = ($rep == 1) ? " multiple" : "";
+            $nameSuffix = ($rep == 1) ? "[]" : "";
+
+            echo "<select name=\"tag" . $tag . $nameSuffix . "\" $TipoS id=\"tag$tag\"";
             if ($lensel <> 0 and $TipoS == " multiple") {
                 if ($selected == true) $lensel--;
                 echo " size=$lensel";

--- a/www/htdocs/central/dataentry/fmt.php
+++ b/www/htdocs/central/dataentry/fmt.php
@@ -439,6 +439,14 @@ function ColocarMfn(){ //PutMFN
 
 function VariablesDeAmbiente($var,$value){ //EnvironmentalVariables
     global $arrHttp,$variables;
+
+	if (is_array($value)) {
+		$value = implode("\n", array_map('trim', $value));
+	} else {
+		$value = trim($value);
+	}
+
+
     if (substr($var,0,3)=="tag") {
 	$ixpos=strpos($var,"_");
 	if ($ixpos!=0) {
@@ -511,7 +519,11 @@ global $arrHttp,$valortag,$tm,$nr,$tl,$tym;
 $ValorCapturado="";
 $arrHttp=Array();
 foreach ($_REQUEST as $var => $value) {
-    if (trim($value)!="") VariablesDeAmbiente($var,$value);
+	if (is_array($value)) {
+		if (count($value) > 0) VariablesDeAmbiente($var, $value);
+	} else {
+		if (trim($value) != "") VariablesDeAmbiente($var, $value);
+	}
 }
 if (!isset($arrHttp["Expresion"]))     $arrHttp["Expresion"]="";
 

--- a/www/htdocs/central/dataentry/scripts_dataentry.php
+++ b/www/htdocs/central/dataentry/scripts_dataentry.php
@@ -388,24 +388,20 @@ function CancelarActualizacion(){
 							case "select-one":
 								break;
 							case "select-multiple":
-								Ctrl = eval("document.forma1." + nombre);
-								for (ixsel = 0; ixsel < Ctrl.length; ixsel++) {
-									if (Ctrl.options[ixsel].selected) {
+								var Ctrl = campo;
+								var cleanNombre = nombre.replace("[]", "");
 
-										// Ignore options whose value is explicitly empty (placeholder)
+								for (var ixsel = 0; ixsel < Ctrl.length; ixsel++) {
+									if (Ctrl.options[ixsel].selected) {
 										if (Ctrl.options[ixsel].value === "") {
-											Ctrl.options[ixsel].selected = false;
 											continue;
 										}
 
-										// Improved validation for 'undefined'
-										if (typeof VC[nombre] === "undefined" || VC[nombre] == "undefined") {
-											VC[nombre] = "S";
-											ValorCapturado = nombre + "_" + Ctrl.options[ixsel].value;
-											Ctrl.options[ixsel].selected = false;
+										if (typeof VC[cleanNombre] === "undefined" || VC[cleanNombre] == "undefined") {
+											VC[cleanNombre] = "S";
+											ValorCapturado = cleanNombre + "_" + Ctrl.options[ixsel].value;
 										} else {
-											ValorCapturado = ValorCapturado + "\n" + nombre + "_" + Ctrl.options[ixsel].value;
-											Ctrl.options[ixsel].selected = false;
+											ValorCapturado = ValorCapturado + "\n" + cleanNombre + "_" + Ctrl.options[ixsel].value;
 										}
 									}
 								}


### PR DESCRIPTION
Add robust support for multi-select form fields and array request values.

- SelectRenderer.php: emit "multiple" attribute and append name[] for repeated/select-multiple fields; fix quoting of name/id.
- fmt.php: VariablesDeAmbiente now accepts array values (joins them with newlines and trims); request parsing only calls VariablesDeAmbiente for non-empty scalars or non-empty arrays to avoid spurious empty entries.
- scripts_dataentry.php: remove eval, use passed element (campo), strip trailing [] for VC keys, skip empty placeholder options, and build ValorCapturado correctly to handle multiple selections.

These changes prevent undefined keys, improve JS safety, and properly capture multi-select values.

Fix error #716 