### PR TITLE
Topbar redesign & add change_password page

### DIFF
--- a/www/htdocs/assets/css/main.css
+++ b/www/htdocs/assets/css/main.css
@@ -12,6 +12,8 @@
 ** 2025-09-12 rogercgui Unifies CSS files in a single Main.CSS file
 ** 2025-11-25 fho4abcd Reduce white space, especially in list/edit a record. Solution is not ideal.
 ** 2025-12-20 fho4abcd Add centered table+nowrap td+ reduced white space
+** 2026-08-25 rogercgui Merge topbar redesign (.heading/.heading-database/.heading-nav/.bt-mod) - see inline notes
+** 2026-09-07 rogercgui Removed duplicate legacy topbar/nav block (tag+class selectors like nav.heading-nav were beating the new rules by specificity, and the 3 separate/conflicting responsive breakpoints were fighting each other) - single consolidated block now lives at 5.1, see note there
 */
 
 /* ==========================================================================
@@ -317,7 +319,7 @@ a.menuButton {
     user-select: none;
     -webkit-user-select: none;
     touch-action: manipulation;
-    border-radius: 0.3rem;
+    border-radius: 1rem;
     display: block;
     float: left;
     height: 50px;
@@ -388,7 +390,7 @@ a.singleButton:hover {
     min-height: 65px;
     background-color: var(--abcd-white, #ffffff);
     border: 1px solid #cccccc;
-    border-radius: 4px;
+    border-radius: 1rem;
     margin: 5px 15px 15px 0;
     text-decoration: none !important;
     /* Anula sublinhado padrão do link */
@@ -765,95 +767,340 @@ div.tooltip-data label {
     display: table;
 }
 
-/* --- 4.2. Header (.heading) --- */
+/* ==========================================================================
+   4.2. Header (.heading)
+   ========================================================================== */
 .heading {
     display: flex;
-    background-color: var(--abcd-steel-blue);
-    height: 45px;
+    align-items: center;
+    background-color: var(--abcd-blue, #1f2937);
+    color: #ffffff;
+    height: 50px !important;
+    padding: 0 1rem;
+    gap: 1.5rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     width: 100%;
+    box-sizing: border-box;
 }
 
 .institutionalInfo {
-    float: left;
-    padding: 2px 10px;
-    height: 40px;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    height: 100%;
+    padding: 0 !important;
 }
 
 .institutionalInfo img {
-    margin: 2px 8px 0 0;
-    display: inline-block;
-    height: 32px;
+    max-height: 32px;
+    object-fit: contain;
 }
 
+/* Seletor de Base de Dados */
 .heading-database {
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    height: 100%;
 }
 
 .heading-database form {
-    margin-right: 15%;
-    padding: 0;
-    height: 45px;
-    position: absolute;
-    width: 39%;
-    vertical-align: middle;
-    text-align: right;
+    display: flex;
+    align-items: center;
+    height: 34px !important;
+    margin: 0 !important;
+    padding: 0 0 0 8px!important;
+    background: rgba(255, 255, 255, 0.15) !important;
+    border-radius: 4px;
+    transition: background 0.2s ease;
 }
 
-.heading-database form label {
-    display: inline-block;
-    vertical-align: middle;
-    margin: 12px 10px 0 30px;
-    font-size: 1rem;
+.heading-database form:hover {
+    background: rgba(255, 255, 255, 0.25) !important;
 }
 
-select.heading-database {
-    display: block;
-    margin-top: 5px;
-    background: var(--abcd-gray-200);
-    color: var(--abcd-steel-blue);
-    width: 60%;
-    border: none;
-    border-radius: inherit;
-    float: right;
-    padding: 8px;
-    height: 35px;
-    border-radius: 3px;
-    box-shadow: rgba(0, 0, 0, .1) inset 0 2px 4px 0;
-    font-weight: 600;
-    font-size: 14px;
-    text-align: left;
+select.heading-database,
+.heading-database select {
+    background-color: transparent !important;
+    color: #ffffff !important;
+    border: none !important;
+    box-shadow: none !important;
+    font-weight: 600 !important;
+    font-size: 0.9rem !important;
+    padding: 0 32px 0 12px !important;
+    height: 100% !important;
+    margin: 0 !important;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'%3E%3Cpath d='M7 10l5 5 5-5z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+    background-size: 18px;
 }
 
-select.heading-database-att {
-    background: var(--abcd-yellow);
-    color: var(--abcd-red);
+select.heading-database:focus {
+    outline: 2px solid var(--abcd-yellow, #ffc107);
 }
 
 select.heading-database option {
-    background: var(--abcd-white);
-    color: var(--abcd-steel-blue);
+    background: var(--abcd-white, #ffffff);
+    color: var(--abcd-steel-blue, #333333);
 }
 
-.userInfo {
-    float: right;
-    text-align: right;
+/* ==========================================================================
+   5.1. Main header navigation (Priority+ Pattern)
+   ========================================================================== */
+.heading-nav,
+nav.heading-nav {
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
+    align-items: center;
+    height: 100%;
+    min-width: 0;
+}
+
+.nav-modules-wrapper {
+    flex: 1;
+    min-width: 0;
+    height: 100%;
+    overflow: hidden;
+    /* Corta visualmente qualquer vazamento */
+    display: flex;
+    /* Essencial para o alinhamento à direita funcionar */
+}
+
+.nav-modules {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin: 0 0 0 auto;
+    /* Empurra a lista para a direita (Substitui o flex-end de forma segura) */
+    padding: 0;
+    height: 100%;
+}
+
+.nav-utilities {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+.nav-module-item {
+    flex-shrink: 0;
+    /* IMPEDE esmagamento dos botões - crucial para a medição do JS */
+}
+
+/* Design unificado para botões no topo */
+.heading-nav button.bt-mod,
+.heading-nav a.bt-util {
+    background: transparent !important;
+    /* Força sobreposição de buttons.css */
+    border: none !important;
+    color: rgba(255, 255, 255, 0.75) !important;
+    height: 50px !important;
+    padding: 0 14px !important;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    transition: all 0.2s ease;
+    border-radius: 0 !important;
+    box-shadow: none !important;
     white-space: nowrap;
-    padding: 15px 15px 0px 0px;
 }
 
-.userInfo a.button_logout {
-    display: -moz-inline-box;
-    display: inline-block;
-    padding: 6px 32px 6px 0px;
-    vertical-align: middle;
+.heading-nav a.bt-util i, .heading-nav button.bt-mod i {
+    margin-right: 6px;
 }
 
-.language {
-    float: right;
-    width: 30%;
-    text-align: right;
-    white-space: nowrap;
-    padding: 0px 47px 0px 0px;
+.heading-nav button.bt-mod:hover,
+.heading-nav a.bt-util:hover {
+    color: #ffffff !important;
+    background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.heading-nav button.bt-mod.active {
+    color: #ffffff !important;
+    background-color: rgba(255, 255, 255, 0.15) !important;
+    border-bottom: 3px solid var(--abcd-yellow, #ffc107) !important;
+}
+
+/* -----------------------------------------------------
+   DROPDOWN "MODS"
+   ----------------------------------------------------- */
+.dropdown-container {
+    position: relative;
+    height: 100%;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.mods-dropdown-menu {
+    display: none;
+    /* Ativado via JS */
+    position: absolute;
+    top: 50px;
+    right: 0;
+    background-color: #ffffff;
+    min-width: 220px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    border-radius: 0 0 6px 6px;
+    border: 1px solid #d1d5db;
+    z-index: 9999;
+    list-style: none;
+    padding: 8px 0;
+    margin: 0;
+}
+
+.mods-dropdown-menu.show-dropdown {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Gira o chevron do botao "Mods" quando o dropdown esta aberto */
+.bt-mods-chevron {
+    transition: transform 0.2s ease;
+}
+
+.bt-mods-toggle.dropdown-open .bt-mods-chevron {
+    transform: rotate(180deg);
+}
+
+/* Reset de visualização para os botões que caírem dentro do dropdown */
+.mods-dropdown-menu .nav-module-item {
+    width: 100%;
+}
+
+.mods-dropdown-menu button.bt-mod {
+    width: 100%;
+    height: 44px !important;
+    padding: 0 16px !important;
+    color: #374151 !important;
+   background-color: var(--abcd-white, #ffffff) !important;
+    border-bottom: none !important;
+    justify-content: flex-start;
+    font-weight: 500;
+}
+
+.mods-dropdown-menu button.bt-mod:hover {
+    background-color: #f3f4f6 !important;
+    color: var(--abcd-blue, #0056b3) !important;
+}
+
+.mods-dropdown-menu button.bt-mod.active {
+    background-color: #e5edff !important;
+    color: var(--abcd-blue, #0056b3) !important;
+    border-left: 4px solid var(--abcd-blue, #0056b3) !important;
+    font-weight: 700;
+}
+
+.mods-dropdown-menu .mod-icon {
+    width: 20px;
+    text-align: center;
+    margin-right: 12px;
+    color: #6b7280;
+}
+
+.mods-dropdown-menu button.bt-mod.active .mod-icon {
+    color: inherit;
+}
+
+/* -----------------------------------------------------
+   Utilitários (Encoding e Perfil)
+   ----------------------------------------------------- */
+.charset-badge {
+    background: rgba(0, 0, 0, 0.25) !important;
+    border: 1px solid rgba(255, 255, 255, 0.2) !important;
+    color: #e2e8f0 !important;
+    font-family: monospace;
+    font-size: 0.75rem !important;
+    padding: 2px 8px !important;
+    height: 24px !important;
+    border-radius: 12px !important;
+    margin: auto 8px;
+}
+
+.user-badge {
+    background: rgba(255, 255, 255, 0.1) !important;
+    border-radius: 25px !important;
+    height: 34px !important;
+    padding: 0 14px 0 10px !important;
+    margin: 8px;
+}
+
+.user-badge i {
+    color: var(--abcd-yellow, #ffc107) !important;
+    font-size: 1.1rem;
+}
+
+/* Sobrescreve regras rígidas do buttons.css para Logout */
+.heading-nav a.bt-exit {
+    background-color: transparent !important;
+    color: rgba(255, 255, 255, 0.75) !important;
+    padding: 0 12px !important;
+}
+
+.heading-nav a.bt-exit:hover {
+    background-color: transparent !important;
+    color: var(--abcd-danger, #fc8181) !important;
+}
+
+/* -----------------------------------------------------
+   Breakpoint intermediario (tablets): esconde os rotulos
+   de texto dos modulos/utilitarios e mantem so os icones,
+   para ganhar espaco ANTES de o JS (Priority+) precisar
+   mover itens para o dropdown "Mods". Os rotulos continuam
+   visiveis dentro do proprio dropdown, onde espaco nao falta.
+   ----------------------------------------------------- */
+@media (max-width: 900px) {
+    .heading-nav .mod-title {
+        display: none !important;
+    }
+
+    .mods-dropdown-menu .mod-title {
+        display: inline !important;
+    }
+
+    .heading-nav button.bt-mod,
+    .heading-nav a.bt-util {
+        padding: 0 10px !important;
+    }
+}
+
+/* ==========================================================================
+   Fallback Responsivo Base
+   ========================================================================== */
+@media (max-width: 768px) {
+    .heading {
+        flex-wrap: wrap;
+        padding: 5px;
+        height: auto !important;
+    }
+
+    .institutionalInfo {
+        display: none;
+    }
+
+    .heading-database {
+        order: 3;
+        width: 100%;
+        padding: 5px 0;
+    }
+
+    .heading-database form {
+        width: 100%;
+    }
+
+    .heading-nav {
+        order: 2;
+        width: 100%;
+    }
 }
 
 /* --- 4.3. Section Information Bar (.sectionInfo) --- */
@@ -1021,169 +1268,22 @@ select.heading-database option {
    5. NAVIGATION
    ========================================================================== */
 
-/* --- 5.1. Main header navigation(nav.heading-nav) --- */
-nav.heading-nav ul {
-    float: right;
-    padding: 0;
-    margin: 0;
-    vertical-align: top;
-    list-style: none;
-    position: relative;
-    overflow: hidden;
-    height: 45px;
-}
-
-nav.heading-nav ul li {
-    display: inline-block;
-    vertical-align: top;
-    float: left;
-}
-
-nav.heading-nav a {
-    display: flex;
-    color: var(--abcd-white);
-    height: 45px;
-    line-height: 60px;
-    text-decoration: none;
-    border: none;
-    padding: 0 8px;
-    vertical-align: top;
-    box-shadow: none;
-    align-items: center;
-}
-
-nav.heading-nav a:hover,
-nav.heading-nav button:hover,
-nav.heading-nav select:hover {
-    background-color: var(--abcd-steel-blue);
-}
-
-nav.heading-nav a img {
-    margin-top: 0;
-    vertical-align: middle;
-}
-
-nav.heading-nav select {
-    text-transform: uppercase;
-    display: block;
-    color: var(--abcd-white);
-    height: 43px;
-    width: 60px;
-    text-decoration: none;
-    border: none;
-    padding: 8px;
-    vertical-align: middle;
-    box-shadow: none;
-    line-height: 60px;
-}
-
-nav.heading-nav select option {
-    padding: 5px;
-}
-
-.lang:active {
-    border: 1px solid #000;
-    pointer-events: initial;
-}
-
-/* ---Main navigation dropdowns --- */
-nav.heading-nav ul ul {
-    z-index: 999999999;
-    display: none;
-    position: absolute;
-    top: 45px;
-    right: 0;
-    left: 200px;
-    /* Adjust as needed */
-}
-
-nav.heading-nav ul li:hover>ul {
-    display: inherit;
-}
-
-nav.heading-nav ul ul li {
-    float: none;
-    display: list-item;
-    position: relative;
-    margin-left: -80px;
-    /* Adjust as needed */
-}
-
-nav.heading-nav ul ul ul li {
-    position: relative;
-    top: -60px;
-}
-
-/* --- Module buttons on the main navigation --- */
-.bt-mod {
-    margin: 4px 0 0 0;
-    height: 42px;
-    width: 42px;
-    border-radius: 0px;
-    box-sizing: border-box;
-    cursor: pointer;
-    outline: 0;
-    padding: 10px;
-    transform: translateY(0);
-    transition: transform 150ms, box-shadow 150ms;
-    user-select: none;
-    -webkit-user-select: none;
-    touch-action: manipulation;
-    background-repeat: no-repeat;
-    background-position: center;
-    border-top-right-radius: 0.3rem;
-    border-top-left-radius: 0.3rem;
-}
-
-.bt-cat {
-    background-image: url(../svg/ic_fluent_book_database_24_regular.svg);
-}
-
-.bt-cat.active {
-    box-shadow: rgba(0, 0, 0, .1) inset 0 2px 4px 0;
-    background-image: url(../svg/ic_fluent_book_database_24_filled.svg);
-}
-
-.bt-loan {
-    background-image: url(../svg/ic_fluent_people_swap_24_regular.svg);
-}
-
-.bt-loan.active {
-    background-image: url(../svg/ic_fluent_people_swap_24_filled.svg);
-}
-
-.bt-acq {
-    background-image: url(../svg/ic_fluent_cart_24_regular.svg);
-}
-
-.bt-acq.active {
-    background-image: url(../svg/ic_fluent_cart_24_filled.svg);
-}
-
-.bt-charset {
-    font-size: small;
-}
-
-nav.heading-nav a.bt-exit {
-    background-color: var(--abcd-danger);
-    border: none;
-    border-radius: 0;
-}
-
-li a.bt-exit:hover {
-    background-color: var(--abcd-danger);
-    border: none;
-}
-
+/* NOTA: a implementacao completa de .heading-nav / .bt-mod / .bt-util /
+   .charset-badge / .user-badge / .bt-exit / .dropdown-container /
+   .mods-dropdown-menu fica UNICAMENTE no bloco "5.1. Main header
+   navigation (Priority+ Pattern)" acima (secao 4.2, perto de .heading).
+   NAO redefina essas classes aqui de novo -- foi exatamente essa
+   duplicacao (um bloco antigo com seletores mais especificos como
+   "nav.heading-nav") que quebrou o layout em 2026-09. */
 
 /* --- 5.2. Generic navigation (Menu de Manutenção) --- */
-nav {
+nav:not(.heading-nav) {
     display: block;
     text-align: center;
     width: 100%;
 }
 
-nav ul {
+nav:not(.heading-nav) ul {
     margin: 0;
     padding: 0;
     list-style: none;
@@ -2321,7 +2421,7 @@ body:first-of-type .homepage .mainBox .boxContent .searchTitles .stInput input.t
 iframe.dataentry-header {
     z-index: 999999999;
     position: relative;
-    height: 45px;
+    height: 50px;
     width: 100%;
     border: none;
 }
@@ -3200,6 +3300,7 @@ div.ABCD_menu:hover {
     .abcd-auto {
         max-width: 100%;
     }
+
 }
 
 /* ==========================================================================
@@ -4023,4 +4124,84 @@ div.ABCD_menu:hover {
     width: 16px;
     height: 16px;
     accent-color: #005aa9;
+}
+
+
+/* -----------------------------------------------------
+   DROPDOWN DO USUÁRIO (Perfil)
+   ----------------------------------------------------- */
+.user-dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 50px;
+    right: 0;
+    background-color: #ffffff;
+    min-width: 200px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    border-radius: 0 0 6px 6px;
+    border: 1px solid #d1d5db;
+    z-index: 9999;
+    list-style: none;
+    padding: 8px 0;
+    margin: 0;
+}
+
+.user-dropdown-menu.show-dropdown {
+    display: flex;
+    flex-direction: column;
+}
+
+.user-dropdown-menu a.bt-dropdown-item{
+    padding: 10px 20px;
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s;
+    background-color: var(--abcd-white) !important;
+    color: #374151 !important;
+    border-radius: 0%;
+}
+
+.bt-user-chevron {
+    transition: transform 0.2s ease;
+}
+
+.bt-user-toggle.dropdown-open .bt-user-chevron {
+    transform: rotate(180deg);
+}
+
+/* Classe reaproveitável para itens (<a> ou <button>) dentro dos dropdowns */
+.bt-dropdown-item {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 10px 16px;
+    background: transparent;
+    border: none;
+    text-align: left;
+    color: #374151;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s ease;
+    text-decoration: none;
+    box-sizing: border-box;
+}
+
+.bt-dropdown-item:hover {
+    background-color: #f3f4f6;
+    color: var(--abcd-blue, #0056b3);
+}
+
+.dropdown-icon {
+    width: 20px;
+    text-align: center;
+    margin-right: 12px;
+    color: #6b7280;
+}
+
+.user-dropdown-menu .dropdown-divider {
+    height: 1px;
+    margin: 4px 0;
+    background-color: #e5e7eb;
+    border-top: solid 1px #c2c2c2;
 }

--- a/www/htdocs/central/common/change_password.php
+++ b/www/htdocs/central/common/change_password.php
@@ -1,0 +1,203 @@
+<?php
+/*
+ * Script: change_password.php
+ * Location: /central/common/change_password.php
+ * Author: Roger Craveiro Guilherme
+ * Description: Dedicated page for authenticated users to change their own password. This script is designed to be secure and user-friendly, providing a straightforward interface for password updates while ensuring that only authorized users can access it. It includes CSRF protection, input validation, and clear feedback messages for the user.
+ * Date: 2026-09-07
+ */
+
+
+session_start();
+require_once("get_post.php");
+
+// 1. Setup Database and Config Paths
+if (isset($arrHttp["db_path"])) {
+    $_SESSION["DATABASE_DIR"] = $arrHttp["db_path"];
+}
+require_once("../config.php");
+
+// 2. Localization Setup
+if (isset($_SESSION["lang"])) {
+    $arrHttp["lang"] = $_SESSION["lang"];
+} else {
+    $arrHttp["lang"] = $lang;
+    $_SESSION["lang"] = $lang;
+}
+include("../lang/admin.php");
+include("../lang/lang.php");
+
+// 3. Access Control: Verify active session (Do not call VerificarUsuario() here)
+if (!isset($_SESSION["login"]) || empty($_SESSION["login"])) {
+    header("Location: logout.php");
+    exit;
+}
+
+// 4. Refuse Emergency User and LDAP
+// Emergency users do not have an MFN in their active session
+if (!isset($_SESSION["mfn_admin"]) || $_SESSION["mfn_admin"] == "") {
+    echo "<script>alert('" . addslashes($msgstr["emergnochgpwd"]) . "'); window.location.href='inicio.php';</script>";
+    exit;
+}
+if (isset($use_ldap) && $use_ldap) {
+    echo "<script>alert('" . addslashes($msgstr["nochgpwdldap"]) . "'); window.location.href='inicio.php';</script>";
+    exit;
+}
+
+// 5. Anti-CSRF Token Generation
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+$csrf_token = $_SESSION['csrf_token'];
+
+$error_message = "";
+
+// 6. Pre-flight Middleware: Intercept POST before delegating to inicio.php
+if (isset($arrHttp['Opcion']) && $arrHttp['Opcion'] === 'chgpsw') {
+    $post_csrf = $arrHttp['csrf_token'] ?? '';
+
+    // Validate CSRF
+    if (!hash_equals($csrf_token, $post_csrf)) {
+        $error_message = $msgstr["csrf_error"] ?? "Security token validation failed. Request blocked.";
+    } else {
+        $new_password = trim($arrHttp['new_password'] ?? '');
+        $confirm_password = trim($arrHttp['confirm_password'] ?? '');
+
+        // Backend Complexity & Match Checks
+        if ($new_password !== $confirm_password) {
+            $error_message = $msgstr["passconfirm"];
+        } elseif (!preg_match('/^[0-9a-zA-Z.,!@#$%^&*?_~\\\\()-]+$/', $new_password)) {
+            $error_message = $msgstr["validpwdchars"];
+        } else {
+            // Validation Passed. Delegate to ABCD's core native handler.
+            require_once("inicio.php");
+            exit;
+        }
+    }
+}
+
+$css_name = (isset($css_name)) ? $css_name . "/" : "";
+
+
+include("header.php");
+include("institutional_info.php");
+?>
+
+
+<div class="sectionInfo">
+    <div class="breadcrumb">
+        <?php echo htmlspecialchars($msgstr["chgpass"], ENT_QUOTES, 'UTF-8'); ?>
+    </div>
+    <div class="actions"></div>
+    <div class="spacer">&#160;</div>
+</div>
+
+<!-- Main Content Area -->
+<div class="middle login">
+    <!-- Reutilizando o container nativo de login (main.css 8.2) -->
+    <div class="loginForm">
+        <div class="boxContent">
+
+            <h3 class="mb-3 color-gray-800" style="border-bottom: 1px solid #eee; padding-bottom: 10px;">
+                <i class="fas fa-shield-alt color-blue"></i>
+                <?php echo htmlspecialchars($msgstr["chgpass"], ENT_QUOTES, 'UTF-8'); ?>
+            </h3>
+
+            <?php if (!empty($error_message)): ?>
+                <!-- Reutilizando a classe .alert nativa do ABCD -->
+                <div class="alert mb-3">
+                    <?php echo htmlspecialchars($error_message, ENT_QUOTES, 'UTF-8'); ?>
+                </div>
+            <?php endif; ?>
+
+            <form name="administra" id="frmChangePassword" action="change_password.php" method="POST" onsubmit="return validateFrontend();">
+                <input type="hidden" name="Opcion" value="chgpsw">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf_token, ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="login" value="<?php echo htmlspecialchars($arrHttp["login"] ?? $_SESSION["login"], ENT_QUOTES, 'UTF-8'); ?>">
+
+                <p><?php echo htmlspecialchars($name ?? '', ENT_QUOTES, $sys_charset); ?>
+                <small> (<?php echo htmlspecialchars($profile ?? '', ENT_QUOTES, $sys_charset); ?>)</small>
+                </p>
+
+                <!-- formRow e textEntry dentro do loginForm forçam o layout 100% (main.css) -->
+                <div class="formRow mb-3">
+                    <label for="current_pwd" class="color-gray-700 font-weight-bold">
+                        <?php echo htmlspecialchars($msgstr["actualpass"], ENT_QUOTES, 'UTF-8'); ?>
+                    </label>
+                    <div style="position: relative;">
+                        <input type="password" name="password" id="current_pwd" class="textEntry" required autocomplete="current-password" style="padding-right: 35px;">
+                        <i class="far fa-eye" onclick="toggleVisibility('current_pwd', this)" style="position: absolute; right: 10px; top: 70%; transform: translateY(-50%); cursor: pointer; color: var(--abcd-gray-600);" title="<?php echo htmlspecialchars($msgstr["ver"], ENT_QUOTES, 'UTF-8'); ?>"></i>
+                    </div>
+                </div>
+
+                <div class="formRow mb-3">
+                    <label for="new_pwd" class="color-gray-700 font-weight-bold">
+                        <?php echo htmlspecialchars($msgstr["newpass"], ENT_QUOTES, 'UTF-8'); ?>
+                    </label>
+                    <div style="position: relative;">
+                        <input type="password" name="new_password" id="new_pwd" class="textEntry" required autocomplete="new-password" style="padding-right: 35px;">
+                        <i class="far fa-eye" onclick="toggleVisibility('new_pwd', this)" style="position: absolute; right: 10px; top: 70%; transform: translateY(-50%); cursor: pointer; color: var(--abcd-gray-600);" title="<?php echo htmlspecialchars($msgstr["ver"], ENT_QUOTES, 'UTF-8'); ?>"></i>
+                    </div>
+                    <span class="color-gray-500" style="font-size: 0.85em; display: block; margin-top: 5px;">
+                        <?php echo htmlspecialchars($msgstr["pwd_policy_help"] ?? "Allowed: letters, numbers, basic symbols. No spaces.", ENT_QUOTES, 'UTF-8'); ?>
+                    </span>
+                </div>
+
+                <div class="formRow mb-4">
+                    <label for="confirm_pwd" class="color-gray-700 font-weight-bold">
+                        <?php echo htmlspecialchars($msgstr["confirmpass"], ENT_QUOTES, 'UTF-8'); ?>
+                    </label>
+                    <div style="position: relative;">
+                        <input type="password" name="confirm_password" id="confirm_pwd" class="textEntry" required autocomplete="new-password" style="padding-right: 35px;">
+                        <i class="far fa-eye" onclick="toggleVisibility('confirm_pwd', this)" style="position: absolute; right: 10px; top: 70%; transform: translateY(-50%); cursor: pointer; color: var(--abcd-gray-600);" title="<?php echo htmlspecialchars($msgstr["ver"], ENT_QUOTES, 'UTF-8'); ?>"></i>
+                    </div>
+                </div>
+
+                <div class="formRow mt-4" style="text-align: right;">
+                    <a class="bt bt-light color-white p-2" href="javascript:history.back()">
+                        <i class="fas fa-times"></i> <?php echo htmlspecialchars($msgstr["cancelar"], ENT_QUOTES, 'UTF-8'); ?>
+                    </a>
+
+                    <button type="submit" class="bt bt-blue color-white p-2">
+                        <i class="fas fa-save"></i> <?php echo htmlspecialchars($msgstr["chgpass"], ENT_QUOTES, 'UTF-8'); ?>
+                    </button>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+    function toggleVisibility(fieldId, iconEl) {
+        var field = document.getElementById(fieldId);
+        if (field.type === "password") {
+            field.type = "text";
+            iconEl.classList.remove("fa-eye");
+            iconEl.classList.add("fa-eye-slash");
+        } else {
+            field.type = "password";
+            iconEl.classList.remove("fa-eye-slash");
+            iconEl.classList.add("fa-eye");
+        }
+    }
+
+    function validateFrontend() {
+        var newPwd = Trim(document.getElementById('new_pwd').value);
+        var confPwd = Trim(document.getElementById('confirm_pwd').value);
+
+        if (newPwd !== confPwd) {
+            alert("<?php echo addslashes($msgstr["passconfirm"]); ?>");
+            return false;
+        }
+
+        var allowedChars = /^[0-9a-zA-Z\.,!@#$%^&*?_~\\\-()]+$/;
+        if (!allowedChars.test(newPwd)) {
+            alert("<?php echo addslashes($msgstr["validpwdchars"]); ?>");
+            return false;
+        }
+        return true;
+    }
+</script>
+
+<?php include("footer.php"); ?>

--- a/www/htdocs/central/common/css_settings.php
+++ b/www/htdocs/central/common/css_settings.php
@@ -35,7 +35,7 @@ if ((isset($def["BODY_BACKGROUND"])) && (!empty($def["BODY_BACKGROUND"]))) {
 } else {
 	echo "
 	BODY {
-		background-color: #ffffff;
+		background-color: #f8fafc;
 	}\n";
 }
 if ((isset($def["COLOR_LINK"])) && (!empty($def["COLOR_LINK"]))) {
@@ -48,7 +48,7 @@ if ((isset($def["COLOR_LINK"])) && (!empty($def["COLOR_LINK"]))) {
 	echo "
 	a,
 	a.menuButton span {
-		color: #336699;
+		color: #2b5c8f;
 	}\n";
 }
 if ((isset($def["HEADING"])) && (!empty($def["HEADING"]))) {
@@ -75,7 +75,7 @@ if ((isset($def["HEADING"])) && (!empty($def["HEADING"]))) {
 	.bt-acq,
 	.bt-opac,
 	.modal {
-		background-color: #003366;
+		background-color: #1a365d;
 	}\n";
 }
 
@@ -90,6 +90,7 @@ if ((isset($def["HEADING_FONTCOLOR"])) && (!empty($def["HEADING_FONTCOLOR"]))) {
 	.bt-loan,
 	.bt-acq,
 	.bt-opac,
+	.user-badge,
 	.modal {
 		color: ".$def["HEADING_FONTCOLOR"].";
 	}\n";
@@ -120,7 +121,7 @@ if ((isset($def["TOOLBAR"])) && (!empty($def["TOOLBAR"]))) {
 	echo "
 	div.toolbar-dataentry,
 	body.toolbar-dataentry {
-		background-color: #f8f8f8;
+		background-color: #f1f5f9;
 	}\n";
 }
 if ((isset($def["USERINFO_FONTCOLOR"])) && (!empty($def["USERINFO_FONTCOLOR"]))) {
@@ -172,7 +173,7 @@ if ((isset($def["SECTIONINFO"])) && (!empty($def["SECTIONINFO"]))){
 	.bt-cat.active,
 	.bt-loan.active,
 	.bt-acq.active  {
-		background-color: #336699;
+		background-color: #2c5282;
 	}\n";
 }
 if ((isset($def["SECTIONINFO_FONTCOLOR"])) && (!empty($def["SECTIONINFO_FONTCOLOR"]))) {
@@ -210,7 +211,7 @@ if ((isset($def["HELPER_FONTCOLOR"])) && (!empty($def["HELPER_FONTCOLOR"]))) {
 	echo "
 	.helper,
 	.helper a{
-		color: #666666;
+		color: #4a5568;
 	}\n";
 }
 if ((isset($def["FOOTER"])) && (!empty($def["FOOTER"]))) {
@@ -234,7 +235,7 @@ if ((isset($def["FOOTER_FONTCOLOR"])) && (!empty($def["FOOTER_FONTCOLOR"]))) {
 	echo "
 	.footer,
 	.footer a{
-		color: #f8f8f8;
+		color: #ffffff;
 	}\n";
 }
 echo "</style>\n";

--- a/www/htdocs/central/common/nav_general_topbar.php
+++ b/www/htdocs/central/common/nav_general_topbar.php
@@ -1,124 +1,290 @@
 <?php
 /*
- * Script: Topbar General Navigation to Central
+ * Script: nav_general_topbar.php
  * Author: Roger Craveiro Guilherme
  * Description: This script generates the top navigation bar for the ABCD Central interface, displaying buttons for Cataloging, Circulation, Acquisitions, OPAC access, and user information based on permissions and configurations.
  * Date: 2026-03-05
  * 
+ * changelog:
+ * 2026-03-05 fho4abcd: Initial creation of the topbar navigation
+ * 20260906 rogercgui - Added support for user dropdown with profile and logout options
+ * 20260907 rogercgui - Added Priority+ overflow handling for module buttons
  */
+
+
+    global $arrHttp, $def, $msgstr, $db_path, $charset, $meta_encoding, $name, $profile, $login, $verify_selbase, $module_odds, $link_logo;
+
+$sys_charset = !empty($charset) ? $charset : (!empty($meta_encoding) ? $meta_encoding : 'UTF-8');
+
+$central = false;
+$circulation = false;
+$acquisitions = false;
+if (isset($_SESSION["permiso"])) {
+    foreach ($_SESSION["permiso"] as $key => $value) {
+        $p = explode("_", $key);
+        if ((isset($p[1]) && $p[1] === "CENTRAL") || str_starts_with($key, "CENTRAL_") || str_starts_with($key, "ADM_")) $central = true;
+        if (str_starts_with($key, "CIRC_")) $circulation = true;
+        if (str_starts_with($key, "ACQ_")) $acquisitions = true;
+    }
+}
+
+$current_base = $arrHttp["base"] ?? $_REQUEST["base"] ?? "";
+$active_mod   = $_SESSION["MODULO"] ?? "";
+$current_lang = $_SESSION["lang"] ?? $_REQUEST["lang"] ?? "en";
+
+$module_registry = [
+    'cat' => [
+        'title'  => $msgstr["catalogacion"] ?? 'Cataloging',
+        'icon'   => 'fas fa-book',
+        'action' => '/central/common/inicio.php',
+        'params' => ['base' => $current_base, 'modulo' => 'catalog', 'lang' => $current_lang],
+        'perm'   => $central,
+        'active' => ($active_mod === "catalog" || $active_mod === "adm")
+    ],
+    'circ' => [
+        'title'  => $msgstr["prestamo"] ?? 'Circulation',
+        'icon'   => 'fas fa-exchange-alt',
+        'action' => '/central/common/inicio.php',
+        'params' => ['base' => $current_base, 'modulo' => 'loan', 'lang' => $current_lang],
+        'perm'   => ($circulation && ($def["SHOW_CIRCULATION"] ?? "Y") === "Y"),
+        'active' => ($active_mod === "loan")
+    ],
+    'acq' => [
+        'title'  => $msgstr["acquisitions"] ?? 'Acquisitions',
+        'icon'   => 'fas fa-shopping-cart',
+        'action' => '/central/common/inicio.php',
+        'params' => ['base' => $current_base, 'modulo' => 'acquisitions', 'lang' => $current_lang],
+        'perm'   => ($acquisitions && ($def["SHOW_ACQUISITION"] ?? "Y") === "Y"),
+        'active' => ($active_mod === "acquisitions")
+    ]
+];
+
+if (function_exists('abcd_run_hook')) {
+    $hook_result = abcd_run_hook('abcd_topbar_modules', $module_registry);
+    if (is_array($hook_result)) {
+        $module_registry = $hook_result;
+    }
+}
+
+$nav_mods_str = $def['NAV_MODS'] ?? 'cat, circ, acq';
+$nav_order = array_map('trim', explode(',', $nav_mods_str));
+
+foreach (array_keys($module_registry) as $registered_slug) {
+    if (!in_array($registered_slug, $nav_order)) {
+        $nav_order[] = $registered_slug;
+    }
+}
 ?>
 
+<nav class="heading-nav" id="heading-nav">
+    <!-- 1. CONTAINER DOS MÓDULOS (Flexível) -->
+    <div class="nav-modules-wrapper" id="nav-modules-wrapper">
+        <ul class="nav-modules" id="nav-modules-list">
+            <?php
+            foreach ($nav_order as $slug) {
+                if (isset($module_registry[$slug]) && $module_registry[$slug]['perm']) {
+                    $mod = $module_registry[$slug];
+                    $active_class = $mod['active'] ? 'active' : '';
+            ?>
+                    <li class="nav-module-item">
+                        <form action="<?php echo htmlspecialchars($mod['action'], ENT_QUOTES, $sys_charset) ?>" method="post" target="_top" class="nav-module-form">
+                            <?php foreach ($mod['params'] as $p_key => $p_val): ?>
+                                <input type="hidden" name="<?php echo htmlspecialchars((string)$p_key, ENT_QUOTES, $sys_charset) ?>" value="<?php echo htmlspecialchars((string)$p_val, ENT_QUOTES, $sys_charset) ?>">
+                            <?php endforeach; ?>
+                            <button class="bt-mod <?php echo $active_class ?>" type="submit" title="<?php echo htmlspecialchars((string)$mod['title'], ENT_QUOTES, $sys_charset) ?>">
+                                <i class="<?php echo htmlspecialchars($mod['icon'], ENT_QUOTES, $sys_charset) ?> mod-icon"></i>
+                                <span class="mod-title"><?php echo htmlspecialchars((string)$mod['title'], ENT_QUOTES, $sys_charset) ?></span>
+                            </button>
+                        </form>
+                    </li>
+            <?php
+                }
+            }
+            ?>
+        </ul>
+    </div>
 
-<nav class="heading-nav">
-    <ul>
+    <!-- 2. BOTÃO "MODS" E DROPDOWN (Overflow) -->
+    <div class="dropdown-container" id="nav-mods-dropdown" style="visibility: hidden; width: 0;">
+        <button class="bt-mod bt-mods-toggle" id="bt-mods-toggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="mods-dropdown-list">
+            <i class="fas fa-th"></i>
+            <span class="mod-title" style="margin-left: 6px;">Mods</span>
+            <i class="fas fa-chevron-down bt-mods-chevron" style="font-size: 0.7em; margin-left: 6px;"></i>
+        </button>
+        <ul class="mods-dropdown-menu" id="mods-dropdown-list" role="menu" aria-label="Mods">
+            <!-- Itens excedentes serão movidos para cá pelo JS -->
+        </ul>
+    </div>
+
+    <!-- 3. UTILITÁRIOS (Fixos à direita) -->
+    <ul class="nav-utilities">
         <?php
-        // Ensures access to global settings
-        global $arrHttp, $def, $msgstr, $db_path;
-
-        $central = "";
-        $circulation = "";
-        $acquisitions = "";
-        $style_cat = "";
-        $style_loan = "";
-        $style_acq = "";
-
-        $show_circ_btn = isset($def["SHOW_CIRCULATION"]) ? $def["SHOW_CIRCULATION"] : "Y";
-        $show_acq_btn  = isset($def["SHOW_ACQUISITION"]) ? $def["SHOW_ACQUISITION"] : "Y";
-        $show_opac_btn = isset($def["SHOW_OPAC_BUTTON"]) ? $def["SHOW_OPAC_BUTTON"] : "Y";
-        $show_charset  = isset($def["SHOW_CHARSET"]) ? $def["SHOW_CHARSET"] : "Y";
-
-        $current_base = "";
-        if (isset($arrHttp["base"])) $current_base = $arrHttp["base"];
-        elseif (isset($_REQUEST["base"])) $current_base = $_REQUEST["base"];
-
-        if (isset($_SESSION["permiso"])) {
-            foreach ($_SESSION["permiso"] as $key => $value) {
-                $p = explode("_", $key);
-                if (isset($p[1]) and $p[1] == "CENTRAL") $central = "Y";
-                if (substr($key, 0, 8) == "CENTRAL_")  $central = "Y";
-                if (substr($key, 0, 5) == "CIRC_")  $circulation = "Y";
-                if (substr($key, 0, 4) == "ACQ_")  $acquisitions = "Y";
-            }
+        $show_opac_btn = $def["SHOW_OPAC_BUTTON"] ?? "Y";
+        if (($central || $circulation || $acquisitions || (isset($verify_selbase) && $verify_selbase === "Y") || isset($module_odds)) && $show_opac_btn === "Y" && isset($link_logo)) {
+            echo '<li><a href="' . htmlspecialchars($link_logo, ENT_QUOTES, $sys_charset) . '" target="_blank" class="bt-util" title="OPAC"><i class="fas fa-globe-americas"></i> <span class="mod-title" style="margin-left: 6px;">OPAC</span></a></li>';
         }
-
-        if ($circulation == "Y" or $acquisitions == "Y" or $central == "Y") {
-
-            // --- CATALOGING (Always visible if you have central permission) ---
-            if ($central == "Y") {
-                if (isset($_SESSION["MODULO"]) && $_SESSION["MODULO"] == "catalog") $style_cat = "active";
+        if (($def["SHOW_CHARSET"] ?? "Y") === "Y") {
+            echo '<li><span class="bt-util charset-badge" title="' . htmlspecialchars($msgstr["page_encoding"] ?? 'Encoding', ENT_QUOTES, $sys_charset) . '">' . htmlspecialchars($sys_charset, ENT_QUOTES, $sys_charset) . '</span></li>';
+        }
         ?>
+        <li class="dropdown-container" id="user-dropdown-container">
+            <button class="bt-util user-badge bt-user-toggle" id="bt-user-toggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="user-dropdown-list" title="<?php echo htmlspecialchars(($name ?? '') . ' (' . ($profile ?? '') . ')', ENT_QUOTES, $sys_charset); ?>">
+                <i class="fas fa-user-circle"></i>
+                <span class="mod-title" style="margin-left: 6px;"><?php echo htmlspecialchars($login ?? '', ENT_QUOTES, $sys_charset); ?></span>
+                <i class="fas fa-chevron-down bt-user-chevron" style="font-size: 0.7em; margin-left: 6px;"></i>
+            </button>
+            <ul class="user-dropdown-menu" id="user-dropdown-list" role="menu" aria-label="User Options">
                 <li>
-                    <form action="/central/common/inicio.php" method="post" accept-charset=utf-8 target="_top">
-                        <input type="hidden" name="base" value="<?php echo $current_base; ?>">
-                        <button class="bt-mod bt-cat <?php echo $style_cat; ?>" type="submit" name=modulo value="catalog" title="<?php echo $msgstr["modulo"] . " " . $msgstr["catalogacion"]; ?>"></button>
-                    </form>
-                </li>
-            <?php
-            }
-
-            // --- CIRCULAÇÃO (Condicional: Permissão + abcd.def) ---
-            if ($circulation == "Y" && $show_circ_btn == "Y") {
-                if (isset($_SESSION["MODULO"]) && $_SESSION["MODULO"] == "loan") $style_loan = "active";
-            ?>
-                <li>
-                    <form action="/central/common/inicio.php" method="post" accept-charset=utf-8 target="_top">
-                        <input type="hidden" name="base" value="<?php echo $current_base; ?>">
-                        <button class="bt-mod bt-loan <?php echo $style_loan; ?>" type="submit" name=modulo value="loan" title="<?php echo $msgstr["modulo"] . " " . $msgstr["prestamo"]; ?>"></button>
-                    </form>
-                </li>
-            <?php
-            }
-
-            // --- ACQUISITION (Conditional: Permission + abcd.def) ---
-            if ($acquisitions == "Y" && $show_acq_btn == "Y") {
-                if (isset($_SESSION["MODULO"]) && $_SESSION["MODULO"] == "acquisitions") $style_acq = "active";
-            ?>
-                <li>
-                    <form action="/central/common/inicio.php" method="post" accept-charset=utf-8 target="_top">
-                        <input type="hidden" name="base" value="<?php echo $current_base; ?>">
-                        <button class="bt-mod bt-acq <?php echo $style_acq; ?>" type="submit" name=modulo value="acquisitions" title="<?php echo $msgstr["modulo"] . " " . $msgstr["acquisitions"]; ?>"></button>
-                    </form>
-                </li>
-            <?php
-            }
-        }
-
-        // --- OPAC BUTTON (Conditional: abcd.def + existing link) ---
-        global $verify_selbase, $module_odds;
-        if (($central == "Y") or ($circulation == "Y") or ($acquisitions == "Y") or (isset($verify_selbase) && $verify_selbase == "Y") or isset($module_odds)) {
-
-            if ($show_opac_btn == "Y" && isset($link_logo)) {
-            ?>
-                <li>
-                    <a href="<?php echo $link_logo; ?>" target="_blank" class="bt-mod" title="OPAC">
-                        <i class="fas fa-globe-americas fa-2x" style="color:white; font-size:1.5em;"></i>
+                    <a href="#" style="text-decoration: none;" class="bt-dropdown-item"><i class="fas fa-user dropdown-icon"></i>
+                        <?php echo htmlspecialchars($name ?? '', ENT_QUOTES, $sys_charset); ?>
+                        <small> (<?php echo htmlspecialchars($profile ?? '', ENT_QUOTES, $sys_charset); ?>)</small>
                     </a>
                 </li>
-            <?php
+                <li><a href="/central/common/change_password.php" class="bt-dropdown-item"><i class="fas fa-key dropdown-icon"></i> Mudar Senha</a></li>
+                <li class="dropdown-divider"></li>
+                <a href="/central/common/logout.php" class="bt-dropdown-item" title="<?php echo htmlspecialchars($msgstr["logout"] ?? 'Logout', ENT_QUOTES, $sys_charset); ?>">
+                    <i class="fas fa-sign-out-alt"></i> <?php echo htmlspecialchars($msgstr["logout"] ?? 'Logout', ENT_QUOTES, $sys_charset); ?>
+                </a>
+        </li>
+    </ul>
+    </li>
+    <?php if (!isset($module_odds)): ?>
+
+    <?php endif; ?>
+    </ul>
+</nav>
+
+<!-- NOVO SCRIPT COMPLETO NO FINAL DO ARQUIVO -->
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        const wrapper = document.getElementById("nav-modules-wrapper");
+        const primaryList = document.getElementById("nav-modules-list");
+        const overflowList = document.getElementById("mods-dropdown-list");
+        const modsDropdown = document.getElementById("nav-mods-dropdown");
+        const toggleBtn = document.getElementById("bt-mods-toggle");
+
+        // Elementos do Dropdown de Usuário
+        const userToggleBtn = document.getElementById("bt-user-toggle");
+        const userDropdownList = document.getElementById("user-dropdown-list");
+        const userDropdownContainer = document.getElementById("user-dropdown-container");
+
+        // ------------------------------------------------------------------
+        // Esta topbar normalmente roda DENTRO de um <iframe> (ex.: o iframe
+        // "header" de inicio_main.php). Um iframe recorta seu conteúdo na
+        // altura da própria caixa: nenhum z-index resolve isso, porque não é
+        // uma disputa de empilhamento, é o limite físico do iframe. Como o
+        // iframe é same-origin, aumentamos a altura do PRÓPRIO <iframe> (via
+        // window.frameElement, visto do lado de fora) só enquanto o dropdown
+        // está aberto, e devolvemos ao normal ao fechar. Zero mudanças em
+        // inicio_main.php; se a página não estiver dentro de um iframe (ou
+        // for cross-origin), window.frameElement é null/inacessível e a
+        // função simplesmente não faz nada.
+        function syncHostIframeForDropdown(openMenuEl) {
+            if (!window.frameElement) return;
+            try {
+                if (openMenuEl) {
+                    const neededHeight = Math.ceil(openMenuEl.getBoundingClientRect().bottom) + 8;
+                    window.frameElement.style.position = 'absolute';
+                    window.frameElement.style.top = '0';
+                    window.frameElement.style.left = '0';
+                    window.frameElement.style.height = neededHeight + 'px';
+                } else {
+                    window.frameElement.style.position = '';
+                    window.frameElement.style.top = '';
+                    window.frameElement.style.left = '';
+                    window.frameElement.style.height = '';
+                }
+            } catch (e) {
+                // iframe cross-origin ou outra restrição do navegador - ignora
             }
         }
 
-        // --- CHARSET (Conditional: abcd.def) ---
-        if ($show_charset == "Y") {
-            ?>
-            <li>
-                <a class="bt-charset" title='<?php echo $msgstr["page_encoding"]; ?>' href="#">
-                    <?php echo isset($charset) ? $charset : (isset($meta_encoding) ? $meta_encoding : ''); ?>
-                </a>
-            </li>
-        <?php } ?>
+        // Abre/fecha dropdown do Mods
+        function setModsDropdownOpen(isOpen) {
+            if (isOpen) setUserDropdownOpen(false); // Fecha o do usuário se abrir o Mods
+            overflowList.classList.toggle('show-dropdown', isOpen);
+            toggleBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            toggleBtn.classList.toggle('dropdown-open', isOpen);
+            syncHostIframeForDropdown(isOpen ? overflowList : null);
+        }
 
-        <li>
-            <a class="bt-charset" href="#" title="<?php echo (isset($name) ? $name : '') . ' (' . (isset($profile) ? $profile : '') . ')'; ?>">
-                <i class="fas fa-user"></i>&nbsp;<?php echo isset($login) ? $login : ''; ?>
-            </a>
-        </li>
+        // Abre/fecha dropdown do Usuário
+        function setUserDropdownOpen(isOpen) {
+            if (isOpen) setModsDropdownOpen(false); // Fecha o Mods se abrir o usuário
+            userDropdownList.classList.toggle('show-dropdown', isOpen);
+            userToggleBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            userToggleBtn.classList.toggle('dropdown-open', isOpen);
+            syncHostIframeForDropdown(isOpen ? userDropdownList : null);
+        }
 
-        <li>
-            <?php if (!isset($module_odds)) { ?>
-                <a class="bt-exit" href="/central/common/logout.php" title='<?php echo $msgstr["logout"]; ?>'>
-                    <img src="/assets/svg/ic_fluent_sign_out_24_regular.svg"></a>
-            <?php } ?>
-        </li>
-    </ul>
-</nav>
+        // Listeners de Clique
+        toggleBtn.addEventListener('click', function(e) {
+            e.stopPropagation();
+            setModsDropdownOpen(!overflowList.classList.contains('show-dropdown'));
+        });
+
+        userToggleBtn.addEventListener('click', function(e) {
+            e.stopPropagation();
+            setUserDropdownOpen(!userDropdownList.classList.contains('show-dropdown'));
+        });
+
+        // Fecha os dropdowns ao clicar fora
+        document.addEventListener('click', function(e) {
+            if (!modsDropdown.contains(e.target)) setModsDropdownOpen(false);
+            if (!userDropdownContainer.contains(e.target)) setUserDropdownOpen(false);
+        });
+
+        // Fecha com Esc
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') {
+                if (overflowList.classList.contains('show-dropdown')) {
+                    setModsDropdownOpen(false);
+                    toggleBtn.focus();
+                }
+                if (userDropdownList.classList.contains('show-dropdown')) {
+                    setUserDropdownOpen(false);
+                    userToggleBtn.focus();
+                }
+            }
+        });
+
+        // Lógica Matemática do Priority+
+        function adjustNav() {
+            if (!wrapper || !primaryList || !overflowList || !modsDropdown) return;
+
+            while (overflowList.firstElementChild) {
+                primaryList.appendChild(overflowList.firstElementChild);
+            }
+
+            modsDropdown.style.visibility = 'hidden';
+            modsDropdown.style.width = '0';
+            setModsDropdownOpen(false);
+
+            const getChildrenWidth = () => {
+                let total = 0;
+                for (let i = 0; i < primaryList.children.length; i++) {
+                    total += primaryList.children[i].offsetWidth;
+                }
+                return total;
+            };
+
+            if (getChildrenWidth() > wrapper.clientWidth) {
+                modsDropdown.style.visibility = 'visible';
+                modsDropdown.style.width = 'auto';
+
+                while (getChildrenWidth() > wrapper.clientWidth && primaryList.children.length > 0) {
+                    overflowList.insertBefore(primaryList.lastElementChild, overflowList.firstElementChild);
+                }
+            }
+        }
+
+        if (window.ResizeObserver) {
+            const observer = new ResizeObserver(adjustNav);
+            observer.observe(wrapper);
+        } else {
+            window.addEventListener('resize', adjustNav);
+        }
+
+        setTimeout(adjustNav, 50);
+    });
+</script>

--- a/www/htdocs/central/dataentry/inicio_main.php
+++ b/www/htdocs/central/dataentry/inicio_main.php
@@ -852,8 +852,6 @@ include "../common/header.php";
 				if (actualHeight > 20) window.savedMenuHeight = actualHeight;
 			} catch (e) {}
 
-			// --- ZERANDO O ESPAÇO EM BRANCO ---
-			// Usamos display: none para remover completamente a barra cinza
 			if (shouldCollapse) {
 				iframeMenu.style.display = 'none';
 				iframeHeader.style.display = 'none';

--- a/www/htdocs/central/dataentry/menubases.php
+++ b/www/htdocs/central/dataentry/menubases.php
@@ -63,6 +63,4 @@ else
 <script>
 top.menu.location.href="menu_main.php?base="+top.base+"<?php echo $inicio?>"
 </script>
-</body>
-</html>
 

--- a/www/htdocs/login.php
+++ b/www/htdocs/login.php
@@ -175,7 +175,6 @@ include("$app_path/lang/lang.php");
 
 			?>
 		</div>
-		<div class="userInfo" style="margin-left: 80%;"><?php echo $meta_encoding ?></div>
 
 		<div class="spacer">&#160;</div>
 	</header>


### PR DESCRIPTION
Redesign the central topbar and add a secure password-change page.

Changes:
- Added central/common/change_password.php: new authenticated UI to change own password with CSRF protection, client/server validation, password visibility toggle, and delegation to inicio.php on success.
- Reworked assets/css/main.css: consolidated/modernized .heading/.heading-database/.heading-nav/.bt-mod rules, removed duplicate legacy block, improved responsive behavior and added dropdown styles (mods & user), priority+ overflow handling and visual refinements.
- Updated central/common/nav_general_topbar.php: refactored module registry, dynamic rendering, user dropdown (link to change_password.php), Priority+ JS to move overflowed modules to a dropdown and sync iframe height for dropdowns.
- Tweaked central/common/css_settings.php: updated default colors/palette and small UI color fixes to match new topbar theme.
- Minor cleanup in login.php: removed duplicate userInfo meta_encoding output.

Rationale: modernize topbar visuals, improve responsive behavior and accessibility, provide a secure built-in password-change workflow, and remove conflicting legacy CSS that broke newer rules.